### PR TITLE
 onclite: fstab: Add F2FS entries for /data and /cache partitions

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -38,6 +38,7 @@
 /dev/block/bootdevice/by-name/system        /            ext4    ro,barrier=1,discard                        wait,avb
 /dev/block/bootdevice/by-name/vendor        /vendor      ext4    ro,barrier=1                                         wait,recoveryonly
 /dev/block/bootdevice/by-name/userdata      /data        ext4    noatime,nosuid,nodev,barrier=1,noauto_da_alloc  latemount,wait,resize,check,fileencryption=ice,quota,encryptable=footer,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata      /data        f2fs    noatime,nosuid,nodev,discard,reserve_root=32768,resgid=1065,fsync_mode=nobarrier    latemount,wait,check,fileencryption=ice,quota,reservedsize=128M
 /devices/platform/soc/7864900.sdhci/mmc_host*        /storage/sdcard1 vfat  nosuid,nodev         wait,voldmanaged=sdcard1:auto,noemulatedsd,encryptable=footer
 /devices/platform/soc/7000000.ssusb/7000000.dwc3/xhci-hcd.0.auto*  /storage/usbotg  vfat  nosuid,nodev  wait,voldmanaged=usbotg:auto
 /devices/soc/7864900.sdhci/mmc_host*        /storage/sdcard1 vfat  nosuid,nodev         wait,voldmanaged=sdcard1:auto,noemulatedsd,encryptable=footer
@@ -45,6 +46,7 @@
 /dev/block/bootdevice/by-name/config        /frp         emmc    defaults                                    defaults
 /dev/block/bootdevice/by-name/misc          /misc        emmc    defaults                                    defaults
 /dev/block/bootdevice/by-name/cache         /cache       ext4    noatime,nosuid,nodev,barrier=1              wait
+/dev/block/bootdevice/by-name/cache         /cache       f2fs    nosuid,nodev,noatime,inline_xattr,flush_merge,data_flush    wait,check
 /dev/block/bootdevice/by-name/modem         /vendor/firmware_mnt    vfat    ro,shortname=lower,uid=0,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
 /dev/block/bootdevice/by-name/dsp           /vendor/dsp         ext4    ro,nosuid,nodev,barrier=1                   wait
 /dev/block/bootdevice/by-name/persist       /mnt/vendor/persist ext4   noatime,nosuid,nodev,barrier=1               wait,check

--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -38,7 +38,7 @@
 /dev/block/bootdevice/by-name/system        /            ext4    ro,barrier=1,discard                        wait,avb
 /dev/block/bootdevice/by-name/vendor        /vendor      ext4    ro,barrier=1                                         wait,recoveryonly
 /dev/block/bootdevice/by-name/userdata      /data        ext4    noatime,nosuid,nodev,barrier=1,noauto_da_alloc  latemount,wait,resize,check,fileencryption=ice,quota,encryptable=footer,reservedsize=128M
-/dev/block/bootdevice/by-name/userdata      /data        f2fs    noatime,nosuid,nodev,discard,reserve_root=32768,resgid=1065,fsync_mode=nobarrier    latemount,wait,check,fileencryption=ice,quota,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata      /data        f2fs    noatime,nosuid,nodev,inline_xattr,discard,fsync_mode=nobarrier    latemount,wait,check,fileencryption=ice,quota,encryptable=footer,reservedsize=128M
 /devices/platform/soc/7864900.sdhci/mmc_host*        /storage/sdcard1 vfat  nosuid,nodev         wait,voldmanaged=sdcard1:auto,noemulatedsd,encryptable=footer
 /devices/platform/soc/7000000.ssusb/7000000.dwc3/xhci-hcd.0.auto*  /storage/usbotg  vfat  nosuid,nodev  wait,voldmanaged=usbotg:auto
 /devices/soc/7864900.sdhci/mmc_host*        /storage/sdcard1 vfat  nosuid,nodev         wait,voldmanaged=sdcard1:auto,noemulatedsd,encryptable=footer
@@ -46,7 +46,7 @@
 /dev/block/bootdevice/by-name/config        /frp         emmc    defaults                                    defaults
 /dev/block/bootdevice/by-name/misc          /misc        emmc    defaults                                    defaults
 /dev/block/bootdevice/by-name/cache         /cache       ext4    noatime,nosuid,nodev,barrier=1              wait
-/dev/block/bootdevice/by-name/cache         /cache       f2fs    nosuid,nodev,noatime,inline_xattr,flush_merge,data_flush    wait,check
+/dev/block/bootdevice/by-name/cache         /cache       f2fs    noatime,nosuid,nodev,inline_xattr           wait,check,formattable
 /dev/block/bootdevice/by-name/modem         /vendor/firmware_mnt    vfat    ro,shortname=lower,uid=0,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
 /dev/block/bootdevice/by-name/dsp           /vendor/dsp         ext4    ro,nosuid,nodev,barrier=1                   wait
 /dev/block/bootdevice/by-name/persist       /mnt/vendor/persist ext4   noatime,nosuid,nodev,barrier=1               wait,check


### PR DESCRIPTION
Allow using F2FS filesystem in Data and Cache partitions.